### PR TITLE
Add PDF link extractor utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ scraper_environment_project/
 │   └── quotes_spider.py         # Scrapy spider that extracts and filters links
 ├── utils/
 │   ├── json_to_csv.py           # Converts and cleans extracted data
+│   └── extract_pdf_link.py      # Parse Légis Québec HTML pages for PDF link
 ├── data/
 │   ├── json/
 │   │   └── links.json           # Raw scraped output
@@ -84,6 +85,7 @@ scraper_environment_project/data/csv/links_cleaned.csv
 * `json_to_csv()`: Converts JSON output to a clean, flat CSV format
 * `compact_column()`: Moves non-blank values upward in a column
 * `full_json_to_cleaned_csv_workflow()`: Full data pipeline
+* `extract_pdf_link(html_file)`: Returns the PDF rendition link from a saved HTML page
 
 ---
 

--- a/scraper_environment_project/scraper_environment_project/utils/__init__.py
+++ b/scraper_environment_project/scraper_environment_project/utils/__init__.py
@@ -1,0 +1,11 @@
+"""Utility helpers for the Scraper Environment Project."""
+
+from .json_to_csv import json_to_csv, compact_column, full_json_to_cleaned_csv_workflow
+from .extract_pdf_link import extract_pdf_link
+
+__all__ = [
+    "json_to_csv",
+    "compact_column",
+    "full_json_to_cleaned_csv_workflow",
+    "extract_pdf_link",
+]

--- a/scraper_environment_project/scraper_environment_project/utils/extract_pdf_link.py
+++ b/scraper_environment_project/scraper_environment_project/utils/extract_pdf_link.py
@@ -1,0 +1,44 @@
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def extract_pdf_link(html_path: Path) -> str | None:
+    """Return the PDF link referenced by the hidden ``renditions`` input.
+
+    Parameters
+    ----------
+    html_path : Path
+        Path to the HTML file.
+
+    Returns
+    -------
+    str | None
+        The value associated with the ``"Pdf"`` key if found, otherwise ``None``.
+    """
+    text = html_path.read_text(encoding="utf-8", errors="ignore")
+    match = re.search(r"id=\"renditions\"\s+value='([^']+)'", text)
+    if not match:
+        return None
+    try:
+        renditions = json.loads(match.group(1))
+    except json.JSONDecodeError:
+        return None
+    return renditions.get("Pdf")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract PDF link from a L\u00e9gis Qu\u00e9bec HTML file")
+    parser.add_argument("html_file", type=Path, help="HTML file to parse")
+    args = parser.parse_args()
+
+    pdf_link = extract_pdf_link(args.html_file)
+    if pdf_link:
+        print(pdf_link)
+    else:
+        raise SystemExit("PDF link not found")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- provide a helper to get the `renditionPdf` target from a saved HTML page
- expose the helper from the utils package
- document the new script in README

## Testing
- `python3 scraper_environment_project/scraper_environment_project/utils/extract_pdf_link.py scraper_environment_project/scraper_environment_project/data/html/REAFIE_20250626_162923.html`


------
https://chatgpt.com/codex/tasks/task_b_685dafb825b0832092462b4a90c188aa